### PR TITLE
Reorganized logic for V-72417

### DIFF
--- a/controls/V-72417.rb
+++ b/controls/V-72417.rb
@@ -54,11 +54,6 @@ following command:
 
     # yum install esc pam_pkcs11
   "
-  if smart_card_status.eql?('enabled')
-    impact 0.5
-  else
-    impact 0.0
-  end
   tag severity: nil
   tag gtitle: "SRG-OS-000375-GPOS-00160"
   tag satisfies: ["SRG-OS-000375-GPOS-00160", "SRG-OS-000375-GPOS-00161",
@@ -73,14 +68,18 @@ following command:
   mfa_pkg_list = input('mfa_pkg_list')
   smart_card_status = input('smart_card_status')
 
-  mfa_pkg_list.each do |pkg|
-    describe package("#{pkg}") do
-      it { should be_installed }
+  if smart_card_status.eql?('enabled')
+    impact 0.5
+    mfa_pkg_list.each do |pkg|
+      describe package("#{pkg}") do
+        it { should be_installed }
+      end
     end
-  end if smart_card_status.eql?('enabled')
-
-  describe "The system is not smartcard enabled" do
-    skip "The system is not using Smartcards / PIVs to fulfil the MFA requirement, this control is Not Applicable."
-  end if !smart_card_status.eql?('enabled')
+  else
+    impact 0.0
+    describe "The system is not smartcard enabled" do
+      skip "The system is not using Smartcards / PIVs to fulfil the MFA requirement, this control is Not Applicable."
+    end
+  end
 end
 

--- a/controls/V-72417.rb
+++ b/controls/V-72417.rb
@@ -77,8 +77,8 @@ control "V-72417" do
   else
     mfa_pkg_list.each do |pkg|
       describe "The package" do
-        subject { package("#{pkg}" ) }
-        expect(subject).to be_installed
+        subject { package("#{pkg}") }
+        it { should be_installed }
       end
     end
   end

--- a/controls/V-72417.rb
+++ b/controls/V-72417.rb
@@ -1,59 +1,56 @@
 control "V-72417" do
   title "The Red Hat Enterprise Linux operating system must have the required
-packages for multifactor authentication installed."
+        packages for multifactor authentication installed."
   desc  "Using an authentication device, such as a CAC or token that is
-separate from the information system, ensures that even if the information
-system is compromised, that compromise will not affect credentials stored on
-the authentication device.
+        separate from the information system, ensures that even if the information
+        system is compromised, that compromise will not affect credentials stored on
+        the authentication device.
 
-    Multifactor solutions that require devices separate from information
-systems gaining access include, for example, hardware tokens providing
-time-based or challenge-response authenticators and smart cards such as the
-U.S. Government Personal Identity Verification card and the DoD Common Access
-Card.
+        Multifactor solutions that require devices separate from information
+        systems gaining access include, for example, hardware tokens providing
+        time-based or challenge-response authenticators and smart cards such as the
+        U.S. Government Personal Identity Verification card and the DoD Common Access
+        Card.
 
-    A privileged account is defined as an information system account with
-authorizations of a privileged user.
+        A privileged account is defined as an information system account with
+        authorizations of a privileged user.
 
-    Remote access is access to DoD nonpublic information systems by an
-authorized user (or an information system) communicating through an external,
-non-organization-controlled network. Remote access methods include, for
-example, dial-up, broadband, and wireless.
+        Remote access is access to DoD nonpublic information systems by an
+        authorized user (or an information system) communicating through an external,
+        non-organization-controlled network. Remote access methods include, for
+        example, dial-up, broadband, and wireless.
 
-    This requirement only applies to components where this is specific to the
-function of the device or has the concept of an organizational user (e.g., VPN,
-proxy capability). This does not apply to authentication for the purpose of
-configuring the device itself (management).
+        This requirement only applies to components where this is specific to the
+        function of the device or has the concept of an organizational user (e.g., VPN,
+        proxy capability). This does not apply to authentication for the purpose of
+        configuring the device itself (management)."
 
-
-  "
-  desc  "rationale", ""
   desc  "check", "
-    Verify the operating system has the packages required for multifactor
-authentication installed.
+        Verify the operating system has the packages required for multifactor
+        authentication installed.
 
-    Check for the presence of the packages required to support multifactor
-authentication with the following commands:
+        Check for the presence of the packages required to support multifactor
+        authentication with the following commands:
 
-    # yum list installed esc
-    esc-1.1.0-26.el7.noarch.rpm
+        # yum list installed esc
+        esc-1.1.0-26.el7.noarch.rpm
 
-    # yum list installed pam_pkcs11
-    pam_pkcs11-0.6.2-14.el7.noarch.rpm
+        # yum list installed pam_pkcs11
+        pam_pkcs11-0.6.2-14.el7.noarch.rpm
 
 
-    If the \"esc\" and \"pam_pkcs11\" packages are not installed, this is a
-finding.
-  "
+        If the \"esc\" and \"pam_pkcs11\" packages are not installed, this is a
+        finding."
+
   desc  "fix", "
-    Configure the operating system to implement multifactor authentication by
-installing the required packages.
+        Configure the operating system to implement multifactor authentication by
+        installing the required packages.
 
-    Install the \"esc\" and \"pam_pkcs11\" packages on the system with the
-following command:
+        Install the \"esc\" and \"pam_pkcs11\" packages on the system with the
+        following command:
 
-    # yum install esc pam_pkcs11
-  "
+        # yum install esc pam_pkcs11"
+
   tag severity: nil
   tag gtitle: "SRG-OS-000375-GPOS-00160"
   tag satisfies: ["SRG-OS-000375-GPOS-00160", "SRG-OS-000375-GPOS-00161",
@@ -68,18 +65,22 @@ following command:
   mfa_pkg_list = input('mfa_pkg_list')
   smart_card_status = input('smart_card_status')
 
-  if smart_card_status.eql?('enabled')
-    impact 0.5
-    mfa_pkg_list.each do |pkg|
-      describe package("#{pkg}") do
-        it { should be_installed }
-      end
+  if smart_card_status.eql?('disabled')
+    impact 0.0
+    describe "The system is not smartcard enabled thus this control is Not Applicable" do
+      skip "The system is not using Smartcards / PIVs to fulfil the MFA requirement, this control is Not Applicable."
+    end 
+  elsif mfa_pkg_list.empty?
+    describe "The required Smartcard packages have not been defined, plese define them in your `inputs`." do
+      subject { mfa_pkg_list }
+      it { should_not be_empty }
     end
   else
-    impact 0.0
-    describe "The system is not smartcard enabled" do
-      skip "The system is not using Smartcards / PIVs to fulfil the MFA requirement, this control is Not Applicable."
+    mfa_pkg_list.each do |pkg|
+      describe "The package" do
+        subject { package("#{pkg}" )}
+        expect(subject).to be_installed
+      end
     end
   end
 end
-

--- a/controls/V-72417.rb
+++ b/controls/V-72417.rb
@@ -1,6 +1,7 @@
 control "V-72417" do
   title "The Red Hat Enterprise Linux operating system must have the required
         packages for multifactor authentication installed."
+
   desc  "Using an authentication device, such as a CAC or token that is
         separate from the information system, ensures that even if the information
         system is compromised, that compromise will not affect credentials stored on
@@ -53,8 +54,7 @@ control "V-72417" do
 
   tag severity: nil
   tag gtitle: "SRG-OS-000375-GPOS-00160"
-  tag satisfies: ["SRG-OS-000375-GPOS-00160", "SRG-OS-000375-GPOS-00161",
-"SRG-OS-000375-GPOS-00162"]
+  tag satisfies: ["SRG-OS-000375-GPOS-00160", "SRG-OS-000375-GPOS-00161", "SRG-OS-000375-GPOS-00162"]
   tag gid: "V-72417"
   tag rid: "SV-87041r4_rule"
   tag stig_id: "RHEL-07-041001"
@@ -78,7 +78,7 @@ control "V-72417" do
   else
     mfa_pkg_list.each do |pkg|
       describe "The package" do
-        subject { package("#{pkg}" )}
+        subject { package("#{pkg}" ) }
         expect(subject).to be_installed
       end
     end


### PR DESCRIPTION
Pulled the conditional impact statements out of the if/then construct
early on and added them to the corresponding section near the
corresponding describe blocks.

- Fixes #17

Signed-off-by: Lesley Kimmel <lesley.j.kimmel@users.noreply.github.com>