### PR TITLE
Resolved datatype comparison issue in V-72223

### DIFF
--- a/controls/V-72223.rb
+++ b/controls/V-72223.rb
@@ -64,8 +64,9 @@ period of inactivity.
   system_activity_timeout = input('system_activity_timeout')
 
   # Get current TMOUT environment variable (active test)
-  describe os_env('TMOUT') do
-    its('content') { should be <= system_activity_timeout }
+  describe 'Environment variable TMOUT' do
+    subject { os_env('TMOUT').content.to_i }
+    it { should be <= system_activity_timeout }
   end
 
   # Check if TMOUT is set in files (passive test)


### PR DESCRIPTION
The control was comparing os_env('value').content to an integer.
os_env('value'}.content returns a string. Updated to convert the
string to an integer (to_i). The output of doing this directly was
poor so I added an explicit subject to clean up the output.

- Fixes #27

Signed-off-by: Lesley Kimmel <lesley.j.kimmel@users.noreply.github.com>