### PR TITLE
Consider limits.d when checking for hard maxlogins

### DIFF
--- a/controls/V-72217.rb
+++ b/controls/V-72217.rb
@@ -78,7 +78,7 @@ to \"10\" for all accounts and/or account types.
   # It is required that at least 1 file contain compliant configuration
   describe "Files configuring maxlogins less than or equal to #{maxlogins_limit}" do
     subject { compliant_files.length }
-    it { should be > 0 }
+    it { should be_positive }
   end
 
   # No files should set 'hard' 'maxlogins' to any noncompliant value

--- a/inspec.yml
+++ b/inspec.yml
@@ -474,3 +474,9 @@ inputs:
   # - 'internal'
   # - 'trusted'
   value: []
+
+# V-72217
+- name: maxlogins_limit
+  description: "The maxium value that can be used for maxlogins."
+  type: Numeric
+  value: 10


### PR DESCRIPTION
Added the functionality of collecting all configuration files under
limits.d. These files are then searched for any global ('*') entries
matching 'hard' and 'maxlogins'. Any file matching but having a
value of anything other than '10' fails.

- Fixes #23

Signed-off-by: Lesley Kimmel <lesley.j.kimmel@users.noreply.github.com>