### PR TITLE
Fixed `undefined variable` error for V-71933

### DIFF
--- a/controls/V-71933.rb
+++ b/controls/V-71933.rb
@@ -46,6 +46,8 @@ the configurations listed in this requirement.
   tag cci: ["CCI-000200"]
   tag nist: ["IA-5 (1) (e)", "Rev_4"]
 
+  min_reuse_generations = input('min_reuse_generations')
+
   describe pam("/etc/pam.d/system-auth") do
     its('lines') { should match_pam_rule('password (required|requisite|sufficient) pam_(unix|pwhistory).so').any_with_integer_arg('remember', '>=', min_reuse_generations) }
   end


### PR DESCRIPTION
Added a variable definition via input (min_reuse_generations).

- Fixes #35

Signed-off-by: Lesley Kimmel <lesley.j.kimmel@users.noreply.github.com>