### PR TITLE
Resolved `undefined local variable` in V-71863

### DIFF
--- a/controls/V-71863.rb
+++ b/controls/V-71863.rb
@@ -134,6 +134,9 @@ Agreement for details.\"
   tag cci: ["CCI-000048"]
   tag nist: ["AC-8 a", "Rev_4"]
 
+  banner_message_text_cli = input('banner_message_text_cli')
+  banner_message_text_cli_limited = input('banner_message_text_cli_limited')
+
   clean_banner = banner_message_text_cli.gsub(%r{[\r\n\s]}, '')
   clean_banner_limited = banner_message_text_cli_limited.gsub(%r{[\r\n\s]}, '')
   banner_file = file("/etc/issue")


### PR DESCRIPTION
Added variable definition via input (banner_message_text_cli).
Added variable definition via input (banner_message_text_cli_limited).

- Fixes #34

Signed-off-by: Lesley Kimmel <lesley.j.kimmel@users.noreply.github.com>