### PR TITLE
Adjusted calculation logic in V-72089

### DIFF
--- a/controls/V-72089.rb
+++ b/controls/V-72089.rb
@@ -69,15 +69,16 @@ to 25 percent of the partition size.
   tag cci: ["CCI-001855"]
   tag nist: ["AU-5 (1)", "Rev_4"]
 
-  if((f = file(audit_log_dir= File.dirname(auditd_conf.log_file))).directory?)
-    partition_info = command("df -h #{@audit_log_dir}").stdout.split("\n")
+  if((f = file(audit_log_dir = command("dirname #{auditd_conf.log_file}").stdout.strip)).directory?)
+    # Fetch partition sizes in 1K blocks for consistency
+    partition_info = command("df -B 1K #{audit_log_dir}").stdout.split("\n")
     partition_sz_arr = partition_info.last.gsub(/\s+/m, ' ').strip.split(" ")
 
-    # Get partition size in GB
-    partition_sz = partition_sz_arr[1].gsub(/G/, '')
+    # Get partition size
+    partition_sz = partition_sz_arr[1]
 
     # Convert to MB and get 25%
-    exp_space_left = partition_sz.to_i * 1024 / 4
+    exp_space_left = partition_sz.to_i / 1024 / 4
 
     describe auditd_conf do
       its('space_left.to_i') { should be >= exp_space_left }


### PR DESCRIPTION
- Removed the `@` symbol from the `#{audit_log_dir}` variable causing
  it to resolve to `nil` and presenting all system partitions.
- Update the shell call to `df` to use standard 1K blocksize instead
  of human readable format which can return results with various units.
- Update the space calculation to convert KB into MB ( / 1024) instead
  of converting [assumed] GB into MB ( * 1024).

- Fixes #32

Signed-off-by: Lesley Kimmel <lesley.j.kimmel@users.noreply.github.com>