### PR TITLE
Allow customization of the A/V solution in use.

### DIFF
--- a/controls/V-72213.rb
+++ b/controls/V-72213.rb
@@ -32,13 +32,25 @@ finding.
   tag cci: ["CCI-001668"]
   tag nist: ["SI-3 a", "Rev_4"]
 
-  describe.one do
-	  describe service('nails') do
-	    it { should be_running }
+  custom_antivirus = input('custom_antivirus')
+
+  if ! custom_antivirus
+    describe.one do
+      describe service('nails') do
+      it { should be_running }
     end
     describe service('clamav-daemon.socket') do
-	    it { should be_running }
-	  end
+      it { should be_running }
+      end
+    end
+  else
+    # Allow user to provide a description of their AV solution
+    # for documentation.
+    custom_antivirus_description = input('custom_antivirus_description')
+    describe "Antivirus: #{custom_antivirus_description}" do
+      subject { custom_antivirus_description }
+      it { should_not cmp 'None' }
+    end
   end
 end
 

--- a/inspec.yml
+++ b/inspec.yml
@@ -480,3 +480,15 @@ inputs:
   description: "The maxium value that can be used for maxlogins."
   type: Numeric
   value: 10
+
+# V-72213
+- name: custom_antivirus
+  description: "Whether an antivirus solution, other than nails, is in use."
+  type: Boolean
+  value: False
+
+- name: custom_antivirus_description
+  description: "Description of custom antivirus solution, when in use."
+  type: String
+  # Default of 'None' is used by control code -- DO NOT CHANGE DEFAULT
+  value: 'None'


### PR DESCRIPTION
Update the control to take a switch/boolean input that specifies
whether a non-nails solution is in use. If it is, require that
a description of the solution be input as a way to document
the solution

- Fixes #24

Signed-off-by: Lesley Kimmel <lesley.j.kimmel@users.noreply.github.com>