### PR TITLE
Updated V-71963 to be NA when EFI not in use

### DIFF
--- a/inspec.yml
+++ b/inspec.yml
@@ -300,16 +300,6 @@ inputs:
   type: Array
   value: ['root']
 
-- name: efi_user_boot_files
-  description: Efi boot config files
-  type: Array
-  value: ['/boot/efi/EFI/redhat/user.cfg']
-
-- name: efi_main_cfg
-  description: Main efi boot config file
-  type: String
-  value: '/boot/efi/EFI/redhat/grub.cfg'
-
 # V-71971
 - name: admin_logins
   description: System accounts that support approved system activities


### PR DESCRIPTION
- Added a check to see if the EFI configuration file exists. If not,
  this becomes NA.
- Added a check for minor version of the OS. If 7.2 or later we only
  allow 'root' as a superuser.
- The STIG guidance states that this is NA for versions after 7.2.
  However, it seems clear that this is still needed it just changes
  the way we enforce it.
- Removed 'efi_user_boot_files'  input as it doesn't matter what file
  the configuration comes from, only that it is merged into the main
  config.
- Removed 'efi_main_cfg' input since we need to make the path dynamic to
  support RHEL variants such as CentOS. Also, the EFI path is pretty
  well static.

- Fixes #40

Signed-off-by: Lesley Kimmel <lesley.j.kimmel@users.noreply.github.com>