### PR TITLE
Updated V-72073 to support overrides

### DIFF
--- a/controls/V-72073.rb
+++ b/controls/V-72073.rb
@@ -68,15 +68,12 @@ uncommented file and directory selection lists.
     it { should be_installed }
   end
 
-  findings = []
-  aide_conf.where { !selection_line.start_with? '!' }.entries.each do |selection|
-    unless selection.rules.include? 'sha512'
-      findings.append(selection.selection_line)
-    end
-  end
+  exclude_patterns = input('aide_exclude_patterns')
+
+  findings = aide_conf.where { !selection_line.start_with?('!') && !exclude_patterns.include?(selection_line) && !rules.include?('sha512')}
 
   describe "List of monitored files/directories without 'sha512' rule" do
-    subject { findings }
+    subject { findings.selection_lines }
     it { should be_empty }
   end
 end

--- a/inspec.yml
+++ b/inspec.yml
@@ -503,4 +503,10 @@ inputs:
     similarly named processes."
   type: Numeric
   value: 1
+
+# V-72073
+- name: aide_exclude_patterns
+  description: 'It is reasonable and advisable to skip checksum on frequently changing files'
+  type: Array
+  value: []
   


### PR DESCRIPTION
- Simplified logic to remove loop searching for 'sha512' entries.
  Instead return them directly with the 'where' clause.
- Provide an input array to contain patterns to exclude from the test.

- Fixes #36

Signed-off-by: Lesley Kimmel <lesley.j.kimmel@users.noreply.github.com>