### PR TITLE
Updating V-72065 to account for fstab entry

### DIFF
--- a/controls/V-72065.rb
+++ b/controls/V-72065.rb
@@ -43,8 +43,16 @@ in the fstab with a device and mount point.
   tag cci: ["CCI-000366"]
   tag nist: ["CM-6 b", "Rev_4"]
 
-  describe systemd_service('tmp.mount') do
-    it { should be_enabled }
+  describe.one do
+    describe systemd_service('tmp.mount') do
+      it { should be_enabled }
+    end
+    describe etc_fstab.where { mount_point == '/tmp' } do
+      its('count') { should cmp 1 }
+      it 'Should have a device name specified' do
+        expect(subject.device_name[0]).to_not(be_empty)
+      end
+    end
   end
 end
 


### PR DESCRIPTION
- Allow /tmp to be specified in /etc/fstab as well as with the tmp.mount
  service.
- Validate that there is only one entry for /tmp in fstab
- Ensure that the device_name is not empty for the mount

- Fixes #37

Signed-off-by: Lesley Kimmel <lesley.j.kimmel@users.noreply.github.com>