### PR TITLE
Updating V-72001 to validate all `allowed_users`

### DIFF
--- a/controls/V-72001.rb
+++ b/controls/V-72001.rb
@@ -52,17 +52,15 @@ allow for a normal user to perform administrative-level actions.
   tag nist: ["CM-6 b", "Rev_4"]
 
   known_system_accounts = input('known_system_accounts')
-  disallowed_accounts = input('disallowed_accounts')
   user_accounts = input('user_accounts')
 
   allowed_accounts = (known_system_accounts + user_accounts).uniq
-
-  describe passwd do
-    its('users') { should be_in allowed_accounts }
-  end
-
-  describe passwd do
-    its('users') { should_not be_in disallowed_accounts }
+  passwd.users.each do |user|
+    describe user do
+      it "is listed in allowed users." do
+        expect(subject).to(be_in allowed_accounts)
+      end
+    end
   end
 end
 

--- a/inspec.yml
+++ b/inspec.yml
@@ -60,15 +60,6 @@ inputs:
   #type: Boolean
   value: false
 
-- name: disallowed_accounts
-  description: Accounts that are not allowed on the system
-  type: Array
-  value: [
-  'games',
-  'gopher',
-  'ftp'
-  ]
-
 - name: user_accounts
   description: Accounts of known managed users
   type: Array
@@ -77,21 +68,27 @@ inputs:
 - name: known_system_accounts
   description: System accounts that support approved system activities.
   type: Array
-  value: [
-    'root',
-    'bin',
-    'daemon',
-    'adm',
-    'lp',
-    'sync',
-    'shutdown',
-    'halt',
-    'mail',
-    'operator',
-    'nobody',
-    'systemd-bus-proxy'
-    ]
-
+  value: 
+    - 'root'
+    - 'bin'
+    - 'daemon'
+    - 'adm'
+    - 'lp'
+    - 'sync'
+    - 'shutdown'
+    - 'halt'
+    - 'mail'
+    - 'operator'
+    - 'nobody'
+    - 'systemd-bus-proxy'
+    - 'dbus'
+    - 'polkitd'
+    - 'postfix'
+    - 'sssd'
+    - 'chrony'
+    - 'systemd-network'
+    - 'sshd'
+    - 'ntp'
 
 # V-71859/V-77819
 - name: dconf_user


### PR DESCRIPTION
- The STIG control asks to validate that all accounts present on the
  system are approved. Explicilty adding them to a known user list
  provides that validation.
- There doesn't seem to be a need for a 'disallowed_users' list as users are
  implicitly disallowed by not being explicitly allowed.
- Use 'expect' syntax to allow for finer control over the reporting
  output. Previous output displayed a list of users for each line. Now we
  just show that each user listed in /etc/passwd has been explicitly
  listed as an approved user.

- Fixes #39

Signed-off-by: Lesley Kimmel <lesley.j.kimmel@users.noreply.github.com>