### PR TITLE
Update V-71897 to allow multiple multiplexers

### DIFF
--- a/controls/V-71897.rb
+++ b/controls/V-71897.rb
@@ -57,8 +57,14 @@ command:
   tag cci: ["CCI-000057"]
   tag nist: ["AC-11 a", "Rev_4"]
 
-  describe package('screen') do
-    it { should be_installed }
+  multiplexer_packages = input('terminal_mux_pkgs')
+
+  describe.one do
+    multiplexer_packages.each do |pkg|  
+      describe package(pkg) do
+        it { should be_installed }
+      end
+    end
   end
 end
 

--- a/inspec.yml
+++ b/inspec.yml
@@ -509,4 +509,12 @@ inputs:
   description: 'It is reasonable and advisable to skip checksum on frequently changing files'
   type: Array
   value: []
+
+# V-71897
+- name: terminal_mux_pkgs
+  description: 'A list of acceptable terminal multiplexers'
+  type: Array
+  value:
+    - tmux
+    - screen
   


### PR DESCRIPTION
- Per v2r6 of the DISA STIG `tmux` is now an allowable option along with
  screen.
- Add an input list to contain `screen` and `tmux` and to support any
  future options.

- Fixes #67

Signed-off-by: Lesley Kimmel <lesley.j.kimmel@users.noreply.github.com>