### PR TITLE
Fixed reporting for V-71947

### DIFF
--- a/controls/V-71947.rb
+++ b/controls/V-71947.rb
@@ -84,8 +84,11 @@ command:
   sudoers = processed.select { |f| file(f).file? }
 
   sudoers.each do |sudoer|
-    describe command("grep -i nopasswd #{sudoer}") do
-      its('stdout') { should_not match %r{^[^#]*NOPASSWD} }
+    sudo_content = file(sudoer).content.strip.split("\n")
+    nopasswd_lines = sudo_content.select { |l| l.match?(/^[^#].*NOPASSWD/) }
+    describe "#{sudoer} rules containing NOPASSWD" do
+      subject { nopasswd_lines }
+      it { should be_empty }
     end
   end
 end


### PR DESCRIPTION
- This control was not splitting output lines into an array and was
  matching ALL lines containing 'NOPASSWD', which included commented
  lines.
- Modified to use the `file` resource to be more OS agnostic and build
  a results array of uncommented lines containing 'NOPASSWD'
- Reporting is improved for readability

- Fixes #90

Signed-off-by: Lesley Kimmel <lesley.j.kimmel@users.noreply.github.com>