### PR TITLE
Correct logic in V-81005

### DIFF
--- a/controls/V-81005.rb
+++ b/controls/V-81005.rb
@@ -64,7 +64,7 @@ the \"### BEGIN /etc/grub.d/01_users ###\" section:
       skip "The System is running UEFI, this control is Not Applicable."
     end
   else
-    unless os[:release] >= "7.2"
+    unless os[:release] < "7.2"
       impact 0.0
       describe "System running version of RHEL prior to 7.2" do
         skip "The System is running an outdated version of RHEL, this control is Not Applicable."


### PR DESCRIPTION
- Only OS versions earlier than 7.2 should be checked. Was checking any
  version 7.2 and later.

- Fixes #91

Signed-off-by: Lesley Kimmel <lesley.j.kimmel@users.noreply.github.com>