### PR TITLE
rewrite of the control

### DIFF
--- a/inspec.yml
+++ b/inspec.yml
@@ -30,11 +30,16 @@ inputs:
     value: true
 
   # SV-204392
-  - name: rpm_verify_perms_except
-    desc: List of system files that should be allowed to change from an rpm verify point of view
+  - name: rpm_verify_ownership_except
+    desc: List of system files that should be allowed to have a different ownership from the default as determined by 'rpm verify'
     type: Array
-    value:
-      - "/etc/issue"
+    value: []
+
+  # SV-204392
+  - name: rpm_verify_group_membership_except
+    desc: List of system files that should be allowed to have a different group membership from the default as determined by 'rpm verify'
+    type: Array
+    value: []
 
   # SV-214799
   - name: rpm_verify_integrity_except

--- a/kitchen.inputs.yml
+++ b/kitchen.inputs.yml
@@ -2,7 +2,7 @@
 # used in the RHEL 7 DISA STIG.
 
 # Controls that are known to consistently have long run times can be disabled with this attribute
-disable_slow_controls: true
+disable_slow_controls: false
 
 # V-72081 - 'monitor_kernel_log', (bool)
 # Set this to false if your system availability concern is not documented or


### PR DESCRIPTION
takes a very long time but that's cause on my spun up rhel7 docker container it ended up processing 15k-ish files and creating 45k-ish tests. printing out a lot of debugging output that will be changed later. changed the inputs around to match the new interpretation of the control and got rid of the exception that we had in there for /etc/issue.

Signed-off-by: Amndeep Singh Mann <me@asm.works>