### PR TITLE
Update workflow to use artifact actions v4

### DIFF
--- a/.github/workflows/update-profile-json.yml
+++ b/.github/workflows/update-profile-json.yml
@@ -13,7 +13,7 @@ jobs:
       - name: add needed packages
         run: sudo apt-get install -y jq
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}

--- a/.github/workflows/update-profile-json.yml
+++ b/.github/workflows/update-profile-json.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.1'
       - run: bundle install
       - name: Regenerate current `profile.json`
         run: |

--- a/.github/workflows/update-profile-json.yml
+++ b/.github/workflows/update-profile-json.yml
@@ -13,7 +13,7 @@ jobs:
       - name: add needed packages
         run: sudo apt-get install -y jq
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -30,7 +30,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SAF_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Clone full repository so we can push
         run: git fetch --prune --unshallow
       - name: Setup Ruby
@@ -48,7 +48,7 @@ jobs:
       - name: Run kitchen test
         run: bundle exec kitchen test --destroy=always ${{ matrix.suite }}-rhel-7 || true
       - name: Save Test Result JSON
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: spec/results/
       - name: Display our ${{ matrix.suite }} results summary

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -30,7 +30,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SAF_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
       - name: Clone full repository so we can push
         run: git fetch --prune --unshallow
       - name: Setup Ruby

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -30,7 +30,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SAF_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Clone full repository so we can push
         run: git fetch --prune --unshallow
       - name: Setup Ruby

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.1'
       - name: Disable ri and rdoc
         run: 'echo "gem: --no-ri --no-rdoc" >> ~/.gemrc'
       - run: bundle install


### PR DESCRIPTION
Changes made:

- Updating artifact actions v3 to v4 since v3 will be deprecated 1/30/2025
- Updated ruby version from 2.7 to 3.1 and actions/checkout v3 to v4